### PR TITLE
Move 4.x series document link to the page bottom.

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -27,9 +27,7 @@ title: Support
 </div>
 
 
-<div class="alert alert-success">
-  <a class="alert-link" href="/docs/4/index.html">ChaiScript 4.x series (requiring boost) Generated Documents.</a>
-</div>
+
 
 
 
@@ -55,6 +53,10 @@ title: Support
       <li class="list-group-item"><a href="docs/5/LangStandardLibraryRef.html">Standard Library</a>: the set of built in scripting functions</li>
       <li class="list-group-item"><a href="docs/5/LangKeywordRef.html">Keyword Reference</a>: the general language syntax and usage</li>
     </ul>
+  </div>
+  
+  <div class="alert alert-success">
+    <a class="alert-link" href="/docs/4/index.html">ChaiScript 4.x series (requiring boost) Generated Documents.</a>
   </div>
 
 </body>


### PR DESCRIPTION
I'd always thought that the expanded 'Getting Starting With The API' and 'Getting Started With Scripting' sections of the documentation page related to the Chaiscript 4.x series. This is due to indention of the panel divs making it look like they are children of the alert-success div related to 4.x documentation at the top of the page.

This change simply moves the 4.x documentation link to the bottom of the page to make it clearer.
