### PR TITLE
Fix #10: Make the railroad grammar diagram part of the hourly build process for the website

### DIFF
--- a/.github/workflows/update-grammar.yml
+++ b/.github/workflows/update-grammar.yml
@@ -1,0 +1,59 @@
+name: Update Grammar Railroad Diagram
+
+on:
+  schedule:
+    - cron: '47 * * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-grammar:
+    name: Generate railroad diagram from EBNF grammar
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Download EBNF grammar
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p grammar
+          gh api repos/ChaiScript/ChaiScript/contents/grammar/chaiscript.ebnf \
+            --jq '.content' | base64 -d > grammar/chaiscript.ebnf
+
+      - name: Download rr-webapp
+        run: |
+          curl -sL \
+            "https://repo1.maven.org/maven2/de/bottlecaps/rr/rr-webapp/2.6/rr-webapp-2.6.war" \
+            -o /tmp/rr.war
+
+      - name: Generate railroad diagram
+        run: |
+          java -jar /tmp/rr.war \
+            -out:grammar/railroad.xhtml \
+            grammar/chaiscript.ebnf
+
+      - name: Check for changes
+        id: changes
+        run: |
+          git add grammar/
+          if git diff --cached --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit and push
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git commit -m "Update grammar railroad diagram from ChaiScript/ChaiScript"
+          git push

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -32,6 +32,9 @@
         <li>
         <a href="https://github.com/ChaiScript/ChaiScript/blob/develop/cheatsheet.md">Cheatsheet</a>
         </li>
+        <li {% if page.url == '/grammar.html'%} class='active' {% endif %}>
+        <a href="/grammar.html">Grammar</a>
+        </li>
         <li {% if page.url == '/docs.html'%} class='active' {% endif %}>
         <a href="/docs.html">Docs</a>
         </li>

--- a/grammar.html
+++ b/grammar.html
@@ -1,0 +1,50 @@
+---
+title: Grammar
+---
+
+<!DOCTYPE HTML>
+<meta http-equiv='Content-Type' content='text/html; charset=utf-8' />
+
+<head>
+<title>ChaiScript - Grammar Railroad Diagram</title>
+{% include common.html %}
+
+<style>
+  .grammar-iframe {
+    width: 100%;
+    min-height: 800px;
+    border: 1px solid #ddd;
+    border-radius: 4px;
+    background: #fff;
+  }
+  .grammar-links {
+    margin-top: 10px;
+    font-size: 0.9rem;
+  }
+</style>
+
+</head>
+
+<body>
+
+{% include header.html %}
+
+<div class="well well-sm">
+  <h3>Grammar Railroad Diagram</h3>
+  <p>Navigable railroad diagram of ChaiScript's syntax, generated from the
+    <a href="https://github.com/ChaiScript/ChaiScript/blob/develop/grammar/chaiscript.ebnf">EBNF grammar</a>
+    using <a href="https://github.com/GuntherRademacher/rr">RR</a>.</p>
+</div>
+
+<div class="body-with-margin">
+  <iframe class="grammar-iframe" src="/grammar/railroad.xhtml" title="ChaiScript grammar railroad diagram"></iframe>
+
+  <div class="grammar-links">
+    <p>
+      <a href="/grammar/railroad.xhtml">Open full-page diagram</a> &middot;
+      <a href="/grammar/chaiscript.ebnf">Download EBNF source</a>
+    </p>
+  </div>
+</div>
+
+</body>

--- a/test_playground.sh
+++ b/test_playground.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Regression test for issue #6: WASM playground
+# Regression tests for the ChaiScript website build artifacts.
 # Validates that all required files exist and contain expected content.
 set -euo pipefail
 
@@ -39,6 +39,22 @@ assert_file_contains "playground.html" "header.html"
 
 # 3. Navigation includes playground link
 assert_file_contains "_includes/header.html" "playground"
+
+# 4. Grammar railroad diagram workflow exists and runs hourly
+assert_file_exists ".github/workflows/update-grammar.yml"
+assert_file_contains ".github/workflows/update-grammar.yml" "schedule"
+assert_file_contains ".github/workflows/update-grammar.yml" "cron:"
+assert_file_contains ".github/workflows/update-grammar.yml" "chaiscript.ebnf"
+assert_file_contains ".github/workflows/update-grammar.yml" "ChaiScript/ChaiScript"
+assert_file_contains ".github/workflows/update-grammar.yml" "rr-webapp"
+
+# 5. Grammar page exists with required elements
+assert_file_exists "grammar.html"
+assert_file_contains "grammar.html" "header.html"
+assert_file_contains "grammar.html" "railroad"
+
+# 6. Navigation includes grammar link
+assert_file_contains "_includes/header.html" "grammar"
 
 if [ "$FAIL" -ne 0 ]; then
   echo ""


### PR DESCRIPTION
Automated fix by @leftibot.

### What changed

> Fix #10: Add grammar railroad diagram to the hourly build process
> Add a new GitHub Actions workflow (update-grammar.yml) that runs hourly
> to fetch the EBNF grammar from ChaiScript/ChaiScript and generate
> navigable railroad diagrams using the RR tool (GuntherRademacher/rr).
> A new grammar.html page embeds the generated diagram with a navigation
> link added to the site header. Regression tests verify the workflow
> configuration, grammar page, and navigation integration.
> Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

### Files
```
 .github/workflows/update-grammar.yml | 59 ++++++++++++++++++++++++++++++++++++
 _includes/header.html                |  3 ++
 grammar.html                         | 50 ++++++++++++++++++++++++++++++
 test_playground.sh                   | 18 ++++++++++-
 4 files changed, 129 insertions(+), 1 deletion(-)
```

Closes #10

_Triggered by @lefticus._